### PR TITLE
[FEAT] 게임 대기 화면으로 이동 기능 추가

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:morning_buddies/screens/home/home_main.dart';
+import 'package:morning_buddies/screens/game/game_start.dart';
 import 'package:morning_buddies/screens/onboarding/onboarding_signin.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:morning_buddies/screens/game/game_jigsaw_puzzle.dart';
+import 'package:morning_buddies/service/time_service.dart';
 import 'package:morning_buddies/widgets/home_bottom_nav.dart';
 import 'firebase_options.dart';
 
@@ -12,11 +14,11 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  MyApp({super.key});
 
   // This widget is the root of your application.
   @override
@@ -27,6 +29,8 @@ class MyApp extends StatelessWidget {
       routes: {
         '/signin': (context) => const SignIn(),
         '/main': (context) => const HomeBottomNav(),
+        '/game_start': (context) => const GameStart(),
+        '/game_puzzle': (context) => const GamePage(),
       },
       home: const SignIn(),
     );

--- a/lib/screens/game/game_jigsaw_puzzle.dart
+++ b/lib/screens/game/game_jigsaw_puzzle.dart
@@ -29,9 +29,9 @@ class _GamePageState extends State<GamePage> {
                   child: Padding(
                     padding: EdgeInsets.all(12.0),
                     child: Image(
-                      fit: BoxFit.cover,
+                      fit: BoxFit.fitWidth,
                       image: AssetImage(
-                          '../../assets/images/main_logo.png'), // 여기에 생성형 AI로 만든 이미지 들어가야 함
+                          'assets/images/main_logo.png'), // 여기에 생성형 AI로 만든 이미지 들어가야 함
                     ),
                   ),
                 ),

--- a/lib/screens/game/game_start.dart
+++ b/lib/screens/game/game_start.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:morning_buddies/utils/design_palette.dart';
+
+class GameStart extends StatefulWidget {
+  const GameStart({super.key});
+
+  @override
+  State<GameStart> createState() => _GameStartState();
+}
+
+class _GameStartState extends State<GameStart> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xff706464),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Image(image: AssetImage('assets/images/main_logo.png')),
+            const SizedBox(height: 24),
+            const SizedBox(
+              width: 258,
+              // height: 129,
+              child: Text(
+                textAlign: TextAlign.center,
+                "알람을 해제하려면 그룹 미션 퍼즐을 완성하세요",
+                style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 36,
+                    fontWeight: FontWeight.bold),
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                  minimumSize: Size(369, 48),
+                  foregroundColor: Colors.white,
+                  backgroundColor: ColorStyles.secondaryOrange),
+              onPressed: () {
+                Navigator.pushNamed(context, "/game_puzzle");
+              },
+              child: const Text(
+                "Start",
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/service/time_service.dart
+++ b/lib/service/time_service.dart
@@ -1,0 +1,27 @@
+// 시간 기반 동작( 특정 시간에 도달시 콜백 실행)
+// Timer 유지 관리
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:morning_buddies/utils/time_utils.dart';
+
+class TimeService {
+  Timer? _timer;
+
+  void alarmAction(DateTime targetTime, VoidCallback onTimeReached) {
+    _timer?.cancel();
+
+    Duration durationUntilTarget = TimeUtils.timeUntil(targetTime);
+
+    if (durationUntilTarget == Duration.zero) {
+      // 설정시간과 현재시간 일치시
+      onTimeReached();
+    } else {
+      _timer = Timer(durationUntilTarget, onTimeReached);
+    }
+  }
+
+  void dispose() {
+    _timer?.cancel();
+  }
+}

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -1,0 +1,10 @@
+// 시간 비교 기능 수행
+// targetTime 과 현재 시간의 차이를 계산
+class TimeUtils {
+  static Duration timeUntil(DateTime targetTime) {
+    DateTime currentTime = DateTime.now();
+    return currentTime.isAfter(targetTime)
+        ? Duration.zero
+        : targetTime.difference(currentTime); // targetTime 까지 남은 시간
+  }
+}

--- a/lib/widgets/home_bottom_nav.dart
+++ b/lib/widgets/home_bottom_nav.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:get/state_manager.dart';
+import 'package:morning_buddies/screens/game/game_start.dart';
 import 'package:morning_buddies/screens/home/home_chat.dart';
 import 'package:morning_buddies/screens/home/home_create.dart';
 import 'package:morning_buddies/screens/home/home_main.dart';
 import 'package:morning_buddies/screens/home/home_profile.dart';
+import 'package:morning_buddies/service/time_service.dart';
 import 'package:morning_buddies/utils/design_palette.dart';
 
 class HomeBottomNav extends StatefulWidget {
@@ -13,6 +16,22 @@ class HomeBottomNav extends StatefulWidget {
 }
 
 class _HomeBottomNavState extends State<HomeBottomNav> {
+  final TimeService _timeService = TimeService();
+  // TargetTime
+  String targetTime = "15:31";
+
+  // String to DateTime
+  DateTime convertToDateTime(String targetTime) {
+    DateTime now = DateTime.now();
+    List<String> timeParts = targetTime.split(":");
+    int hour = int.parse(timeParts[0]);
+    int minute = int.parse(timeParts[1]);
+
+    return DateTime(now.year, now.month, now.day, hour, minute);
+  }
+
+  late DateTime convertedTargetTime = convertToDateTime(targetTime);
+
   int _currentIndex = 0;
   final List<Widget> _pages = [
     const HomeMain(),
@@ -25,6 +44,26 @@ class _HomeBottomNavState extends State<HomeBottomNav> {
     setState(() {
       _currentIndex = index;
     });
+  }
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    _timeService.alarmAction(convertedTargetTime, _navigateToGameScreen);
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    _timeService.dispose();
+    super.dispose();
+  }
+
+  void _navigateToGameScreen() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (context) => const GameStart()),
+    );
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.6"
+  get:
+    dependency: "direct main"
+    description:
+      name: get
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.6"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
    http: ^1.2.2
    flutter_dotenv: ^5.1.0
    flame: ^1.18.0
+   get: ^4.6.6
 
 dev_dependencies:
    flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:morning_buddies/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Logic
1. 사실상 main 의 역할을 하는 home_bottom_nav.dart 에 시간 비교 로직, 시간 일치시 로직 클래스를 활용.(home_bottom_nav.dart 는 로그인/회원가입 이후 처음으로 도달하는 위젯, 따라서 이 위젯이 실행될때 타이머 계산을 실행함으로써 Foreground에서 타이머를 따로 시작 함수 생성 없이 동작 가능)

3. String으로 targetTime을 넘겨주면, 이를 DateTime 타입으로 변환

4. convertedTargetTime과, DateTime.now() 의 차이를 계산

5. Duration.zero 라면 화면 이동

- 추가 util 설명
1. time_utils : 설정시간과 현재 시간의 차이를 계산
3. time_service : time_utils에서 반환한 Duration을 가져와서, 비동기 작업을 수행
 